### PR TITLE
Fix Typos in `chain.ex` and `ordered_cache.ex`

### DIFF
--- a/apps/explorer/lib/explorer/chain.ex
+++ b/apps/explorer/lib/explorer/chain.ex
@@ -2256,7 +2256,7 @@ defmodule Explorer.Chain do
   end
 
 
-  # preload_to_detect_tt?: we don't need to preload more than one token transfer in case the tx inside the list (we dont't show any token transfers on tx tile in new UI)
+  # preload_to_detect_tt?: we don't need to preload more than one token transfer in case the tx inside the list (we don't show any token transfers on tx tile in new UI)
   def preload_token_transfers(
         %Transaction{hash: tx_hash, block_hash: block_hash} = transaction,
         necessity_by_association,

--- a/apps/explorer/lib/explorer/chain/ordered_cache.ex
+++ b/apps/explorer/lib/explorer/chain/ordered_cache.ex
@@ -246,7 +246,7 @@ defmodule Explorer.Chain.OrderedCache do
 
       defp merge_and_update([], existing, size) do
         # if there are no more candidates to be inserted keep as many of the
-        # exsisting elements and remove the rest
+        # existing elements and remove the rest
         {remaining, to_remove} = Enum.split(existing, size)
         remove(to_remove)
         remaining


### PR DESCRIPTION
# Pull Request: Fix Typos in `chain.ex` and `ordered_cache.ex`

## Description
This pull request fixes typos in the following files:
- **`chain.ex`**: Corrected "dont't" to "don't" in a comment.
- **`ordered_cache.ex`**: Corrected "exsisting" to "existing" in a comment.

## Changes
- **File:** `apps/explorer/lib/explorer/chain.ex`
  - Original: `# preload_to_detect_tt?: we dont't need to preload more than one token transfer in case the tx inside the list (we dont't show any token transfers on tx tile in new UI)`
  - Updated: `# preload_to_detect_tt?: we don't need to preload more than one token transfer in case the tx inside the list (we don't show any token transfers on tx tile in new UI)`
  
- **File:** `apps/explorer/lib/explorer/chain/ordered_cache.ex`
  - Original: `# exsisting elements and remove the rest`
  - Updated: `# existing elements and remove the rest`

## Motivation and Context
The changes address minor spelling errors in the code comments to improve readability and prevent confusion.

## Checklist
- [x] I have reviewed the changes for correctness.
- [x] I have updated the documentation where necessary.
- [x] My changes do not introduce new issues.

## Notes
- These changes are limited to fixing typos in the comments and do not affect the code’s functionality.
- Thank you for reviewing this pull request!
